### PR TITLE
Add UCP classification rules and validation contract

### DIFF
--- a/configs/use-case-points/actor-classification-rules.json
+++ b/configs/use-case-points/actor-classification-rules.json
@@ -1,0 +1,12 @@
+{
+  "version": "ucp-actor-classification-v1",
+  "rules": [
+    {"classification": "simple", "weight": 1, "definition": "External system or API interaction with well-defined protocol and no human UI complexity."},
+    {"classification": "average", "weight": 2, "definition": "System interaction with richer protocol, transformation, or moderate integration complexity."},
+    {"classification": "complex", "weight": 3, "definition": "Human user interacting through a GUI or another actor requiring significant interaction complexity."}
+  ],
+  "notes": [
+    "Classify actors by interaction complexity, not business importance.",
+    "If evidence is insufficient, mark unclassified and fail validation rather than guessing."
+  ]
+}

--- a/configs/use-case-points/usecase-classification-rules.json
+++ b/configs/use-case-points/usecase-classification-rules.json
@@ -1,0 +1,12 @@
+{
+  "version": "ucp-usecase-classification-v1",
+  "rules": [
+    {"classification": "simple", "transactions_min": 0, "transactions_max": 3, "weight": 5},
+    {"classification": "average", "transactions_min": 4, "transactions_max": 7, "weight": 10},
+    {"classification": "complex", "transactions_min": 8, "transactions_max": 9999, "weight": 15}
+  ],
+  "notes": [
+    "Transactions are counted from the use-case specification, not inferred from actor importance.",
+    "If transaction count is ambiguous, validation should flag it for human review."
+  ]
+}

--- a/references/use-case-points/transaction-counting-rules.md
+++ b/references/use-case-points/transaction-counting-rules.md
@@ -1,0 +1,31 @@
+# UCP Transaction Counting Rules
+
+## Purpose
+Define how transaction counts are derived from use-case specifications for UCP classification.
+
+## Counting principle
+A transaction is a meaningful interaction step across the system boundary that advances the use case.
+
+## Count as transactions
+- Actor input that causes system processing
+- System response that returns meaningful state or output to an actor
+- Distinct request/response interactions with external systems when explicitly part of the use-case flow
+
+## Do not count separately
+- Pure UI formatting or cosmetic rendering details
+- Validation wording variants that do not change control flow
+- Logging/audit internals unless they are explicit use-case behavior across the boundary
+
+## Ambiguity rules
+Flag for review when:
+- the main flow is too abstract to count consistently
+- alternate flows appear to hide core main-flow steps
+- a single bullet combines multiple interactions
+- background integrations are implied but not specified
+
+## Output expectation
+Transaction counting should return:
+- `transaction_count`
+- `counting_notes`
+- `ambiguity_flags`
+- `derived_from_sections` (main flow, alternate flow, exception flow)

--- a/references/use-case-points/ucp-validation-rules.md
+++ b/references/use-case-points/ucp-validation-rules.md
@@ -1,0 +1,39 @@
+# UCP Artifact Validation Rules
+
+## Purpose
+Define deterministic validation checks for interview and RUP artifacts before estimation.
+
+## Validation categories
+1. Completeness
+2. Consistency
+3. Classification readiness
+4. Estimation readiness
+
+## Core checks
+### Completeness
+- Missing actor IDs or names
+- Missing use-case trigger
+- Missing preconditions or postconditions
+- Empty main success scenario
+- Missing non-functional requirements when referenced
+
+### Consistency
+- Actor IDs referenced by use cases must exist in actor catalog
+- NFR references must resolve to supplementary specification entries
+- Use-case IDs must be unique
+- Business-goal references must resolve when present
+
+### Classification readiness
+- Actor descriptions must be sufficient for simple/average/complex classification
+- Transaction count must be derivable or explicitly flagged
+- Use-case classification must follow configured thresholds
+
+### Estimation readiness
+- TCF and ECF ratings must be complete
+- No unclassified actors/use cases may proceed to final estimation
+- Any ambiguity flags must be surfaced to human review
+
+## Severity levels
+- `error`: estimation must stop
+- `warning`: estimation may proceed with caution and explicit note
+- `info`: helpful note only

--- a/schemas/use-case-points/ucp-validation-report.schema.json
+++ b/schemas/use-case-points/ucp-validation-report.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alfredlobster/alfred-skills/schemas/use-case-points/ucp-validation-report.schema.json",
+  "title": "UCP Validation Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "status", "findings"],
+  "properties": {
+    "version": { "type": "string", "const": "ucp-validation-report-v1" },
+    "status": { "type": "string", "enum": ["pass", "warning", "fail"] },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "category", "message"],
+        "properties": {
+          "severity": { "type": "string", "enum": ["error", "warning", "info"] },
+          "category": { "type": "string", "enum": ["completeness", "consistency", "classification_readiness", "estimation_readiness"] },
+          "location": { "type": "string" },
+          "message": { "type": "string", "minLength": 1 },
+          "recommended_action": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implements the next UCP foundation slice:\n- actor classification rules\n- use-case classification rules\n- transaction counting rules\n- validation rules and validation report schema\n\nAddresses #21, #22, and #23